### PR TITLE
Allow detection of cloaking and uncloaking in leaveplayer and joinplayer callbacks

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -14,6 +14,8 @@ cloaking.get_objects_in_area        = minetest.get_objects_in_area
 cloaking.get_server_status          = minetest.get_server_status
 
 local cloaked_players = {}
+local cloaking_players = {}
+local uncloaking_players = {}
 local chatcommands_modified = false
 
 -- Override built-in functions
@@ -261,11 +263,13 @@ function cloaking.cloak(player_or_name)
         t = areas.hud[victim]
     end
 
+    cloaking_players[victim] = true
     for _, f in ipairs(minetest.registered_on_leaveplayers) do
         if f ~= delayed_uncloak then
             f(player, false, 'cloaking')
         end
     end
+    cloaking_players[victim] = nil
 
     cloaked_players[victim] = true
 
@@ -299,9 +303,11 @@ function cloaking.uncloak(player_or_name)
         minetest.chat_send_all("*** " .. victim .. " joined the game.")
     end
 
+    uncloaking_players[victim] = true
     for _, f in ipairs(minetest.registered_on_joinplayers) do
         f(player)
     end
+    uncloaking_players[victim] = nil
 
     minetest.log('verbose', victim .. ' was uncloaked.')
 end
@@ -380,6 +386,15 @@ end
 function cloaking.is_cloaked(player)
     if type(player) ~= "string" then player = player:get_player_name() end
     return cloaked_players[player] and true or false
+end
+
+function cloaking.is_cloaking(player)
+    if type(player) ~= "string" then player = player:get_player_name() end
+    return cloaking_players[player] and true or false
+end
+function cloaking.is_uncloaking(player)
+    if type(player) ~= "string" then player = player:get_player_name() end
+    return uncloaking_players[player] and true or false
 end
 
 -- Prevent cloaked players dying


### PR DESCRIPTION
The broader goal of this PR is to allow for other mods to be more usable while cloaked, if they can detect cloaking and uncloaking in the leaveplayer and joinplayer callbacks, they can decide whether or not to actually perform the action.

This will allow more comprehensive solutions to problems like this: https://github.com/minetest-mods/unified_inventory/pull/248

Changes:
- Added new records for players who are cloaking and uncloaking
- Added api methods for querying the records
- Update the records only around the cloaking and uncloaking calls